### PR TITLE
Implement a Get Contacts list endpoint - first page only

### DIFF
--- a/src/KeapSdk/Keap.Sdk/Clients/Common/KeapListDto.cs
+++ b/src/KeapSdk/Keap.Sdk/Clients/Common/KeapListDto.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Keap.Sdk.Domain.Clients;
+using Newtonsoft.Json;
 using System;
 using System.Text;
 using System.Web;
@@ -24,12 +25,12 @@ namespace Keap.Sdk.Clients.Common
             if (this.Next.Contains("?") && this.Next.StartsWith("http"))
             {
                 Uri link = new Uri(this.Next);
-                var originalParts = HttpUtility.ParseQueryString(CleanupQueryString(link.Query));
+                var originalParts = HttpUtility.ParseQueryString(RestHelper.CleanupQueryString(link.Query));
 
                 // Only add
                 if (!string.IsNullOrWhiteSpace(additionalParameters))
                 {
-                    var additionalParts = HttpUtility.ParseQueryString(CleanupQueryString(additionalParameters));
+                    var additionalParts = HttpUtility.ParseQueryString(RestHelper.CleanupQueryString(additionalParameters));
                     originalParts.Add(additionalParts);
                 }
 
@@ -37,49 +38,6 @@ namespace Keap.Sdk.Clients.Common
             }
 
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(toEncode));
-        }
-
-        /// <summary>
-        /// Removes any leading question mark or trailing ampersand
-        /// </summary>
-        /// <param name="value">Value to cleanup</param>
-        /// <returns></returns>
-        private static string CleanupQueryString(string value)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return string.Empty;
-            }
-
-            if (value.StartsWith("?"))
-            {
-                if (value.Length > 1)
-                {
-                    // Changes '?param1=val1&param2=val2&' to 'param1=val1&param2=val2&'
-                    value = value.Substring(1);
-                }
-                else
-                {
-                    // Changes '?' to ''
-                    value = string.Empty;
-                }
-            }
-
-            if (value.EndsWith("&"))
-            {
-                // Changes 'param1=val1&param2=val2&' to 'param1=val1&param2=val2&'
-                if (value.Length > 1)
-                {
-                    value = value.Substring(0, value.Length - 1);
-                }
-                else
-                {
-                    // Changes '&' to ''
-                    value = string.Empty;
-                }
-            }
-
-            return value;
         }
     }
 }

--- a/src/KeapSdk/Keap.Sdk/Clients/Contacts/ContactListDto.cs
+++ b/src/KeapSdk/Keap.Sdk/Clients/Contacts/ContactListDto.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Keap.Sdk.Clients.Contacts
+{
+    internal class ContactListDto : Common.KeapListDto
+    {
+        [JsonProperty("contacts")]
+        internal List<ContactGetDto> Contacts { get; set; }
+    }
+}

--- a/src/KeapSdk/Keap.Sdk/Clients/Contacts/ContactsClient.cs
+++ b/src/KeapSdk/Keap.Sdk/Clients/Contacts/ContactsClient.cs
@@ -1,5 +1,8 @@
 ﻿using Keap.Sdk.Domain;
+using Keap.Sdk.Domain.Clients;
+using Keap.Sdk.Domain.Common;
 using Keap.Sdk.Domain.Contacts;
+using System;
 using System.Threading.Tasks;
 
 namespace Keap.Sdk.Clients.Contacts
@@ -53,6 +56,40 @@ namespace Keap.Sdk.Clients.Contacts
             var resultDto = Domain.Clients.RestHelper.ProcessResults<ContactGetDto>(response);
 
             var result = resultDto.MapTo();
+
+            return result;
+        }
+
+        public ResultPage<Contact> GetContacts(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = null, string orderDirection = null, bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true)
+        {
+            var responseTask = GetContactsAsync(pageSize, email, givenName, familyName, lastUpdatedSince, lastUpdatedUntil, order, orderDirection, includeLeadSourceId, includeCustomFields, includeJobTitle).ConfigureAwait(false).GetAwaiter();
+            var result = responseTask.GetResult();
+
+            return result;
+        }
+
+        public async Task<ResultPage<Contact>> GetContactsAsync(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = null, string orderDirection = null, bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true)
+        {
+            if (pageSize <= 0 || pageSize > 1000)
+            {
+                pageSize = 1000;
+            }
+            string path = $"contacts?limit={pageSize}&email={email}&given_name={givenName}&family_name={familyName}&order={order}&order_direction={orderDirection}&since={lastUpdatedSince}&unit={lastUpdatedUntil}";
+
+            var responseTask = apiClient.GetAsync(path);
+            var response = await responseTask;
+            var resultDto = Domain.Clients.RestHelper.ProcessResults<ContactListDto>(response);
+
+            ResultPage<Contact> result = new ResultPage<Contact>();
+            if (resultDto.Contacts != null && resultDto.Contacts.Count > 0)
+            {
+                result.NextPageToken = resultDto.GetNextPageToken(); // $"email={email}&include_partners={givenName}"
+
+                foreach (var item in resultDto.Contacts)
+                {
+                    result.Items.Add(item.MapTo());
+                }
+            }
 
             return result;
         }

--- a/src/KeapSdk/Keap.Sdk/Domain/IContactsClient.cs
+++ b/src/KeapSdk/Keap.Sdk/Domain/IContactsClient.cs
@@ -1,4 +1,6 @@
-﻿using Keap.Sdk.Domain.Contacts;
+﻿using Keap.Sdk.Domain.Common;
+using Keap.Sdk.Domain.Contacts;
+using System;
 using System.Threading.Tasks;
 
 namespace Keap.Sdk.Domain
@@ -36,5 +38,59 @@ namespace Keap.Sdk.Domain
         /// <param name="contactId">The ID of the contact</param>
         /// <returns>A contact if it exists, otherwise returns null.</returns>
         Task<Contact> GetContactAsync(int contactId);
+
+        /// <summary>
+        /// Retrieves a list of all contacts
+        /// </summary>
+        /// <param name="pageSize">Sets a total of items to return. Limit of 1000.</param>
+        /// <param name="email">Optional email address to query on</param>
+        /// <param name="givenName">Optional first name or forename to query on</param>
+        /// <param name="familyName">Optional last name or surname to query on</param>
+        /// <param name="lastUpdatedSince">Date to start searching from on LastUpdated</param>
+        /// <param name="lastUpdatedUntil">Date to search to on LastUpdated</param>
+        /// <param name="order">
+        /// Attribute to order items by. Id, date_created, name, firstName, email
+        /// </param>
+        /// <param name="orderDirection">
+        /// How to order the data i.e. ascending (A-Z) or descending (Z-A)
+        /// </param>
+        /// <param name="includeLeadSourceId">
+        /// Will populate the Lead Source ID. Not returning this could improve performance.
+        /// </param>
+        /// <param name="includeCustomFields">
+        /// Will populate the custom fields. Not returning this could improve performance.
+        /// </param>
+        /// <param name="includeJobTitle">
+        /// Will populate the job title. Not returning this could improve performance.
+        /// </param>
+        /// <returns>Returns a list of contacts</returns>
+        public ResultPage<Contact> GetContacts(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = null, string orderDirection = null, bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true);
+
+        /// <summary>
+        /// Retrieves a list of all contacts
+        /// </summary>
+        /// <param name="pageSize">Sets a total of items to return. Limit of 1000.</param>
+        /// <param name="email">Optional email address to query on</param>
+        /// <param name="givenName">Optional first name or forename to query on</param>
+        /// <param name="familyName">Optional last name or surname to query on</param>
+        /// <param name="lastUpdatedSince">Date to start searching from on LastUpdated</param>
+        /// <param name="lastUpdatedUntil">Date to search to on LastUpdated</param>
+        /// <param name="order">
+        /// Attribute to order items by. Id, date_created, name, firstName, email
+        /// </param>
+        /// <param name="orderDirection">
+        /// How to order the data i.e. ascending (A-Z) or descending (Z-A)
+        /// </param>
+        /// <param name="includeLeadSourceId">
+        /// Will populate the Lead Source ID. Not returning this could improve performance.
+        /// </param>
+        /// <param name="includeCustomFields">
+        /// Will populate the custom fields. Not returning this could improve performance.
+        /// </param>
+        /// <param name="includeJobTitle">
+        /// Will populate the job title. Not returning this could improve performance.
+        /// </param>
+        /// <returns>Returns a list of contacts</returns>
+        public Task<ResultPage<Contact>> GetContactsAsync(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = null, string orderDirection = null, bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true);
     }
 }

--- a/src/KeapSdk/Keap.Tests.E2E/ContactTests.cs
+++ b/src/KeapSdk/Keap.Tests.E2E/ContactTests.cs
@@ -28,7 +28,7 @@ namespace Keap.Tests.E2E
             expected.FamilyName = nameFaker.LastName();
             expected.GivenName = nameFaker.FirstName();
             var emailAddress = new Sdk.Domain.Contacts.EmailAddress();
-            emailAddress.Email = internetFaker.Email();
+            emailAddress.Email = Guid.NewGuid().ToString() + "@weekendproject.app";
             emailAddress.Field = Sdk.Domain.Contacts.EmailFieldType.EMAIL1;
 
             expected.EmailAddresses.Add(emailAddress);
@@ -58,6 +58,24 @@ namespace Keap.Tests.E2E
             // Assert
             actual.Should().NotBeNull();
             actual.Id.Should().Be(validId);
+        }
+
+        [Scenario("Get the initial contacts page with default values")]
+        [Given("any token")]
+        [When("a call to get a list of contacts by ID is made")]
+        [Then("a populated contact is returned")]
+        [TestMethod]
+        public void Get_the_initial_contacts_page_with_default_values()
+        {
+            // Arrange
+            var client = ClientHelper.GetSdkClient(PersonaType.Admin);
+
+            // Act
+            var actual = client.Contacts.GetContacts();
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Items.Count.Should().BeGreaterThan(0);
         }
     }
 }


### PR DESCRIPTION
* Gets a list of contacts with optional parameters on the query string. 
* Query strings are now cleaned up before making request in the ApiClient (this is a global change) before sending to the endpoint. Cleanup involves removing trailing ampersands, removing parameters when there is no value
* Improved logging of requests to the endpoints for testing via the LogEventManager.