### PR TITLE
Page through contacts

### DIFF
--- a/src/KeapSdk/Keap.Sdk/Clients/Common/KeapListDto.cs
+++ b/src/KeapSdk/Keap.Sdk/Clients/Common/KeapListDto.cs
@@ -1,6 +1,7 @@
 ﻿using Keap.Sdk.Domain.Clients;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Specialized;
 using System.Text;
 using System.Web;
 
@@ -17,7 +18,7 @@ namespace Keap.Sdk.Clients.Common
         [JsonProperty("previous")]
         public string Previous { get; set; }
 
-        public string GetNextPageToken(string additionalParameters = null)
+        public string GetNextPageToken(NameValueCollection additionalParameters = null)
         {
             // TODO: parse the string from the "Next" item and grab out the limit and offset
             //"next": "https://api.infusionsoft.com/crm/rest/v1/users/?limit=1&offset=1000",
@@ -28,10 +29,21 @@ namespace Keap.Sdk.Clients.Common
                 var originalParts = HttpUtility.ParseQueryString(RestHelper.CleanupQueryString(link.Query));
 
                 // Only add
-                if (!string.IsNullOrWhiteSpace(additionalParameters))
+                if (additionalParameters != null)
                 {
-                    var additionalParts = HttpUtility.ParseQueryString(RestHelper.CleanupQueryString(additionalParameters));
-                    originalParts.Add(additionalParts);
+                    foreach (var key in originalParts.AllKeys)
+                    {
+                        if (additionalParameters[key] != null)
+                        {
+                            // Remove duplicate keys
+                            additionalParameters.Remove(key);
+                        }
+                    }
+
+                    if (additionalParameters.Count > 0)
+                    {
+                        originalParts.Add(additionalParameters);
+                    }
                 }
 
                 toEncode = originalParts.ToString();

--- a/src/KeapSdk/Keap.Sdk/Clients/RestApiClient.cs
+++ b/src/KeapSdk/Keap.Sdk/Clients/RestApiClient.cs
@@ -119,6 +119,7 @@ namespace Keap.Sdk.Domain.Clients
                 catch (Exception ex)
                 {
                     LogEventManager.Info($"Could not parse JSON:{Environment.NewLine}{json}");
+                    LogEventManager.Error(ex);
                 }
             }
             return output;

--- a/src/KeapSdk/Keap.Sdk/Clients/RestHelper.cs
+++ b/src/KeapSdk/Keap.Sdk/Clients/RestHelper.cs
@@ -117,9 +117,14 @@ namespace Keap.Sdk.Domain.Clients
 
         internal static System.Collections.Specialized.NameValueCollection ConvertPageTokenToNameValueCollection(string nextPageToken)
         {
-            var queryString = Encoding.UTF8.GetString(Convert.FromBase64String(nextPageToken));
+            var queryString = ExtractQueryStringFromPageToken(nextPageToken);
             var nvp = System.Web.HttpUtility.ParseQueryString(queryString);
             return nvp;
+        }
+
+        internal static string ExtractQueryStringFromPageToken(string nextPageToken)
+        {
+            return Encoding.UTF8.GetString(Convert.FromBase64String(nextPageToken));
         }
 
         internal static T ProcessResults<T>(ServerResponse serverResponse)

--- a/src/KeapSdk/Keap.Sdk/Domain/IContactsClient.cs
+++ b/src/KeapSdk/Keap.Sdk/Domain/IContactsClient.cs
@@ -64,7 +64,7 @@ namespace Keap.Sdk.Domain
         /// Will populate the job title. Not returning this could improve performance.
         /// </param>
         /// <returns>Returns a list of contacts</returns>
-        public ResultPage<Contact> GetContacts(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = null, string orderDirection = null, bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true);
+        public ResultPage<Contact> GetContacts(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = "id", string orderDirection = "ascending", bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true);
 
         /// <summary>
         /// Retrieves a list of all contacts using the next page token. If there is not a next page,
@@ -101,7 +101,7 @@ namespace Keap.Sdk.Domain
         /// Will populate the job title. Not returning this could improve performance.
         /// </param>
         /// <returns>Returns a list of contacts</returns>
-        public Task<ResultPage<Contact>> GetContactsAsync(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = null, string orderDirection = null, bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true);
+        public Task<ResultPage<Contact>> GetContactsAsync(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = "id", string orderDirection = "ascending", bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true);
 
         /// <summary>
         /// Retrieves a list of all contacts using the next page token. If there is not a next page,

--- a/src/KeapSdk/Keap.Sdk/Domain/IContactsClient.cs
+++ b/src/KeapSdk/Keap.Sdk/Domain/IContactsClient.cs
@@ -67,6 +67,16 @@ namespace Keap.Sdk.Domain
         public ResultPage<Contact> GetContacts(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = null, string orderDirection = null, bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true);
 
         /// <summary>
+        /// Retrieves a list of all contacts using the next page token. If there is not a next page,
+        /// no token will be returned
+        /// </summary>
+        /// <param name="nextPageToken">
+        /// The next page token is returned with every contact list unless there are no results.
+        /// </param>
+        /// <returns></returns>
+        public ResultPage<Contact> GetContacts(string nextPageToken);
+
+        /// <summary>
         /// Retrieves a list of all contacts
         /// </summary>
         /// <param name="pageSize">Sets a total of items to return. Limit of 1000.</param>
@@ -92,5 +102,15 @@ namespace Keap.Sdk.Domain
         /// </param>
         /// <returns>Returns a list of contacts</returns>
         public Task<ResultPage<Contact>> GetContactsAsync(int pageSize = 1000, string email = null, string givenName = null, string familyName = null, DateTimeOffset? lastUpdatedSince = null, DateTimeOffset? lastUpdatedUntil = null, string order = null, string orderDirection = null, bool includeLeadSourceId = false, bool includeCustomFields = false, bool includeJobTitle = true);
+
+        /// <summary>
+        /// Retrieves a list of all contacts using the next page token. If there is not a next page,
+        /// no token will be returned
+        /// </summary>
+        /// <param name="nextPageToken">
+        /// The next page token is returned with every contact list unless there are no results.
+        /// </param>
+        /// <returns></returns>
+        public Task<ResultPage<Contact>> GetContactsAsync(string nextPageToken);
     }
 }

--- a/src/KeapSdk/Keap.Tests.E2E/ContactTests.cs
+++ b/src/KeapSdk/Keap.Tests.E2E/ContactTests.cs
@@ -65,6 +65,32 @@ namespace Keap.Tests.E2E
             actual.Items[0].Id.Should().NotBe(next.Items[0].Id);
         }
 
+        [Scenario("Get additional contact pages using the next page token with a first name specified")]
+        [Given("any access token and a valid next page token")]
+        [When("a call to get a list of contacts is made with a next page token ")]
+        [Then("a list of contacts is returned")]
+        [TestMethod]
+        public void Get_additional_contact_pages_using_the_next_page_token_with_a_first_name_specified()
+        {
+            // Arrange
+            var givenName = "leone";
+            var client = ClientHelper.GetSdkClient(PersonaType.Admin);
+            var original = client.Contacts.GetContacts(pageSize: 1, givenName: givenName);
+
+            // TODO: Create at least 3 records
+
+            // Act
+            var actual = client.Contacts.GetContacts(original.NextPageToken);
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Items.Count.Should().Be(1);
+            actual.NextPageToken.Should().NotBeNullOrWhiteSpace();
+            actual.Items[0].Id.Should().NotBe(original.Items[0].Id);
+            original.Items[0].GivenName.Should().BeEquivalentTo(givenName);
+            actual.Items[0].GivenName.Should().BeEquivalentTo(givenName);
+        }
+
         [Scenario("Get contact by a valid ID should return a contact")]
         [Given("any token and a valid contact ID")]
         [When("a call to get a contact by ID is made")]

--- a/src/KeapSdk/Keap.Tests.E2E/ContactTests.cs
+++ b/src/KeapSdk/Keap.Tests.E2E/ContactTests.cs
@@ -41,6 +41,30 @@ namespace Keap.Tests.E2E
             actual.Id.Should().BeGreaterThan(0);
         }
 
+        [Scenario("Get additional contact pages using the next page token")]
+        [Given("any access token and a valid next page token")]
+        [When("a call to get a list of contacts is made with a next page token ")]
+        [Then("a list of contacts is returned")]
+        [TestMethod]
+        public void Get_additional_contact_pages_using_the_next_page_token()
+        {
+            // Arrange
+            var client = ClientHelper.GetSdkClient(PersonaType.Admin);
+            var original = client.Contacts.GetContacts(pageSize: 1);
+            // TODO: Create at least 3 records
+
+            // Act
+            var actual = client.Contacts.GetContacts(original.NextPageToken);
+            var next = client.Contacts.GetContacts(actual.NextPageToken);
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.Items.Count.Should().Be(1);
+            actual.NextPageToken.Should().NotBeNullOrWhiteSpace();
+            actual.Items[0].Id.Should().NotBe(original.Items[0].Id);
+            actual.Items[0].Id.Should().NotBe(next.Items[0].Id);
+        }
+
         [Scenario("Get contact by a valid ID should return a contact")]
         [Given("any token and a valid contact ID")]
         [When("a call to get a contact by ID is made")]
@@ -62,8 +86,8 @@ namespace Keap.Tests.E2E
 
         [Scenario("Get the initial contacts page with default values")]
         [Given("any token")]
-        [When("a call to get a list of contacts by ID is made")]
-        [Then("a populated contact is returned")]
+        [When("a call to get a list of contacts is made")]
+        [Then("a populated list of contacts is returned with a next page token")]
         [TestMethod]
         public void Get_the_initial_contacts_page_with_default_values()
         {
@@ -76,6 +100,7 @@ namespace Keap.Tests.E2E
             // Assert
             actual.Should().NotBeNull();
             actual.Items.Count.Should().BeGreaterThan(0);
+            actual.NextPageToken.Should().NotBeNullOrWhiteSpace();
         }
     }
 }


### PR DESCRIPTION
Implement get contact list with page token. Create a pattern in which missing parameters that do not come back in the next page link are actually carried over to the next request.